### PR TITLE
Patched path handling to allow for separate build directories

### DIFF
--- a/lib/middleware.coffee
+++ b/lib/middleware.coffee
@@ -34,6 +34,9 @@ module.exports = (options = {}) ->
 
     # Default dest dir to source
     dest = if options.dest then options.dest else src
+    dest = "/" + dest if dest.indexOf("/") isnt 0
+
+    baseDir = options.baseDir ? ""
 
     # Default compile callback
     options.compile ?= (str, options) ->
@@ -43,9 +46,9 @@ module.exports = (options = {}) ->
     (req, res, next) ->
         return next() if 'GET' isnt req.method and 'HEAD' isnt req.method
         pathname = url.parse(req.url).pathname
-        if /\.js$/.test pathname
-            jsPath = path.join dest, pathname
-            coffeePath = path.join src, pathname.replace '.js', '.coffee'
+        if /\.js$/.test(pathname) and pathname.indexOf(dest) is 0
+            jsPath = path.join baseDir, pathname
+            coffeePath = path.join baseDir, src, pathname[dest.length...].replace '.js', '.coffee'
 
             # Ignore ENOENT to fall through as 404
             error = (err) ->


### PR DESCRIPTION
The original path handling prevented having a separate build directory from the source directory (i.e. `/src/app.coffee` compiling to `/build/app.js` when the latter is requested).

I patched the path handling and added a `baseDir` option. Assuming you want your files to look like this:

```
my-app/
  |-- index.coffee     # your express server
  |-- public/
       |-- src/
            |-- app.coffee
       |-- build/
            |-- app.js
```

you'll need to pass in these options (in CoffeeScript):

```
app.use require('connect-coffee-script')
  src: 'src'
  dest: 'build'
  baseDir: path.join(__dirname, 'public')
```

With this setup, a request from the browser for `/build/app.js` will check `my-app/public/src/app.coffee` as the source file, and recompile if necessary, saving the result to `my-app/public/build/app.js`
