### PR TITLE
specifying "lastest" as dep version in package.json is problematic

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
     "version": "0.0.4",
     "description": "Simple connect middleware to serve CoffeeScript files",
     "author": "David Worms <david@adaltas.com>",
-    "contributors": [ 
+    "contributors": [
         { "name": "David Worms", "email": "david@adaltas.com" }
     ],
     "engines": { "node": ">= 0.6.0" },
     "dependencies" : {
-        "coffee-script" : "latest",
-        "debug" : "latest",
-        "mkdirp": "latest"
+        "coffee-script" : "1.x",
+        "debug" : "0.x",
+        "mkdirp": "0.x"
     },
     "devDependencies" : {
         "rimraf" : "latest",


### PR DESCRIPTION
If this library requires the latest coffeescript, npm shrinkwrap fails like this:

```
npm WARN unmet dependency /Users/plyons/projects/othenticate.com/node_modules/connect-coffee-script requires coffee-script@'latest' but will load
npm WARN unmet dependency /Users/plyons/projects/othenticate.com/node_modules/coffee-script,
npm WARN unmet dependency which is version 1.4.0
```

Changing that to a more liberal spec like "1.x" solves the problem.
