### PR TITLE
Added `coffee-script` as a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   ],
   "engines": { "node": ">= 0.6.0" },
   "dependencies" : {
+    "coffee-script" : "latest",
     "debug" : "latest",
     "mkdirp": "latest"
   },
   "devDependencies" : {
-    "coffee-script" : "latest",
     "rimraf" : "latest",
     "mocha": "latest",
     "should": "latest"


### PR DESCRIPTION
Hey there,

Whenever I tried loading `connect-coffee-script`, it would complain that the `coffee-script` module isn't found. This pull request hopefully fixes the issue.
