### PR TITLE
Add coffee path to compile function

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ set the `bare` option, or define additional functions.
 By default the compile function simply renders the JavaScript.
 
 ```javascript
-function compile(str, options) {
+function compile(str, options, coffeePath) {
   options.bare = true;
   return coffeeScript.compile(str, options);
 }

--- a/src/middleware.coffee
+++ b/src/middleware.coffee
@@ -64,7 +64,7 @@ module.exports = (options = {}) ->
         fs.readFile coffeePath, 'utf8', (err, str) ->
           return error err if err
           try
-            js = options.compile str, options
+            js = options.compile str, options, coffeePath
           catch err
             return next err
           debug('render %s', coffeePath);


### PR DESCRIPTION
I would like to add the path of the file when defining a custom compile function. I added this in my pull request as well as in the readme file.

The reason for this is because I was trying to use snockets inside the compile function which needs the path of the file to determine where the other files are. With this being the third parameter we can pass this to snockets and use that in conjunction with this middleware.
