### PR TITLE
specifying "lastest" as dep version in package.json is problematic

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   ],
   "engines": { "node": ">= 0.6.0" },
   "dependencies" : {
-    "coffee-script" : "latest",
-    "debug" : "latest",
-    "mkdirp": "latest"
+    "coffee-script" : "~1.4",
+    "debug" : "~0.7",
+    "mkdirp": "~0.3"
   },
   "devDependencies" : {
     "rimraf" : "latest",


### PR DESCRIPTION
Updated PR from #6
Please, merge, it's good idea to use versions.
