### PR TITLE
introduces the sourceMap changes from #19 and adds a  sourceMayRoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Options:
 *   `baseDir`   Base directory for path resolution
 *   `prefix`    Path which should be stripped from `src`
 *   `sourceMap` Generates source map files
+*   `sourceMapRoot` but added back to the sourceMap url.
 
 Basic example
 -------------

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -71,13 +71,7 @@ module.exports = function(options) {
       return next();
     }
     pathname = url.parse(req.url).pathname;
-    if (options.inspectPrefix && 0 !== pathname.indexOf(options.inspectPrefix)) {
-      return next();
-    }
     if (/\.js$/.test(pathname)) {
-      if (options.replacePrefix && 0 === pathname.indexOf(options.replacePrefix)) {
-        pathname = pathname.substring(options.replacePrefix.length);
-      }
       if (options.prefix && 0 === pathname.indexOf(options.prefix)) {
         pathname = pathname.substring(options.prefix.length);
       }
@@ -110,17 +104,14 @@ module.exports = function(options) {
           }
           debug('render %s', coffeePath);
           return mkdirp(path.dirname(jsPath), 0x1c0, function(err) {
-            var mapFile, mapFooter, mapPath;
+            var mapFile, mapFooter, mapPath, _ref1;
 
             if (err) {
               return error(err);
             }
             if (map != null) {
               mapFile = jsPath.replace(/\.js$/, '.map');
-              mapPath = pathname.replace(/\.js$/, '.map');
-              if (options.replacePrefix) {
-                mapPath = options.replacePrefix + mapPath;
-              }
+              mapPath = ((_ref1 = options.sourceMapRoot) != null ? _ref1 : '') + pathname.replace(/\.js$/, '.map');
               mapFooter = "//@ sourceMappingURL=" + mapPath + "\n";
               js = "" + js + "\n\n" + mapFooter;
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-coffee-script",
-  "version": "0.1.5",
+  "version": "0.1.3",
   "description": "Simple connect middleware to serve CoffeeScript files",
   "homepage": "https://github.com/wdavidw/node-connect-coffee-script",
   "author": "David Worms <david@adaltas.com>",

--- a/src/middleware.coffee
+++ b/src/middleware.coffee
@@ -41,10 +41,7 @@ module.exports = (options = {}) ->
   (req, res, next) ->
     return next() if 'GET' isnt req.method and 'HEAD' isnt req.method
     pathname = url.parse(req.url).pathname
-    return next() if options.inspectPrefix and 0 isnt pathname.indexOf options.inspectPrefix
     if /\.js$/.test pathname
-      if options.replacePrefix and 0 is pathname.indexOf options.replacePrefix
-        pathname = pathname.substring options.replacePrefix.length
       if options.prefix and 0 is pathname.indexOf options.prefix
         pathname = pathname.substring options.prefix.length
       jsPath = path.join dest, pathname
@@ -79,8 +76,7 @@ module.exports = (options = {}) ->
             return error err if err
             if map?
               mapFile = jsPath.replace /\.js$/, '.map'
-              mapPath = pathname.replace /\.js$/, '.map'
-              mapPath = options.replacePrefix + mapPath if options.replacePrefix
+              mapPath = (options.sourceMapRoot ? '') + pathname.replace /\.js$/, '.map'
               mapFooter = "//@ sourceMappingURL=#{mapPath}\n"
               # Special comment at the end that is required to signify to WebKit dev tools
               # that a source map is available:

--- a/test/middleware.coffee
+++ b/test/middleware.coffee
@@ -62,21 +62,21 @@ describe 'middleware', ->
           content.should.eql "alert(\'welcome\');\n"
           next()
 
-  it 'should strip and replace path', (next) ->
+  it 'prepend the sourcemap location with the sourceMapRoot', (next) ->
     rimraf "#{__dirname}/../sample/public", (err) ->
       options =
-        src: "#{__dirname}/../sample/view"
+        src: "#{__dirname}/../sample/view",
         dest: "#{__dirname}/../sample/public",
         sourceMap: true,
-        replacePrefix: "/static"
+        sourceMapRoot: '/static'
       req =
-        url: 'http://localhost/static/test.js'
+        url: 'http://localhost/test.js'
         method: 'GET'
       res = {}
       middleware(options) req, res, () ->
         fs.readFile "#{__dirname}/../sample/public/test.js", 'utf8', (err, content) ->
           should.not.exist err
-          content.should.eql "//@ sourceMappingURL=/static/test.map\n\n(function() {\n  alert(\'welcome\');\n\n}).call(this);\n"
+          content.should.eql "(function() {\n  alert(\'welcome\');\n\n}).call(this);\n\n\n//@ sourceMappingURL=/static/test.map\n"
           next()
 
   it 'should strip path', (next) ->
@@ -96,42 +96,6 @@ describe 'middleware', ->
           content.should.eql "(function() {\n  alert(\'welcome\');\n\n}).call(this);\n"
           fs.unlink "#{__dirname}/prefix/public/js/test.js"
           next()
-
-  it 'should kick in when the inspectPrefix matches', (next) ->
-    rimraf "#{__dirname}/../sample/public", (err) ->
-      options =
-          baseDir: "#{__dirname}/prefix"
-          src: './view/coffee'
-          dest: './public/js'
-          prefix: '/js'
-          inspectPrefix: '/js'
-        req =
-          url: 'http://localhost/js/test.js'
-          method: 'GET'
-        res = {}
-        middleware(options) req, res, () ->
-          fs.readFile "#{__dirname}/prefix/public/js/test.js", 'utf8', (err, content) ->
-            should.not.exist err
-            content.should.eql "(function() {\n  alert(\'welcome\');\n\n}).call(this);\n"
-            fs.unlink "#{__dirname}/prefix/public/js/test.js"
-            next()
-
-  it 'should do nothing when the inspectPrefix does not match', (next) ->
-    rimraf "#{__dirname}/../sample/public", (err) ->
-      options =
-          baseDir: "#{__dirname}/prefix"
-          src: './view/coffee'
-          dest: './public/js'
-          prefix: '/js'
-          inspectPrefix: '/co'
-        req =
-          url: 'http://localhost/js/test.js'
-          method: 'GET'
-        res = {}
-        middleware(options) req, res, () ->
-          fs.exists "#{__dirname}/prefix/public/js/test.js", (exists) ->
-            exists.should.not.be.ok
-            next()
 
   it 'should show filename on error', (next) ->
     rimraf "#{__dirname}/../sample/public", (err) ->


### PR DESCRIPTION
I'm sorry this has introduced so many commits many of which are me reverting changes I made and pushed to my repository, but this introduces 2 changes
1) the changes made by @timvanelsloo that fixed sourceMaps has been introduced with changes made to the coffeescript file and the generated js file.
2) added a new option called sourceMapRoot that adds a root the location of the sourceMap.

I had originally introduced 2 different options to do the same thing
 i) inspectPrefix which would make sure the middleware only kicked in when the pathname to the js matched a specific prefix
ii) replacePrefix which would remove the prefix but add it back to the path to the sourceMap.
However, I realised that a lot of this can be accomplished automatically with expressjs since the first parameter to the `use` method of an express app is a static mount point. sourceMapRoot helps adjust the url exposed to the user 
