### PR TITLE
Depend on coffee-script 1.7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "engines": { "node": ">= 0.6.0" },
   "dependencies" : {
-    "coffee-script" : "*",
+    "coffee-script" : "1.7.x",
     "debug" : "*",
     "mkdirp": "*"
   },


### PR DESCRIPTION
`updateSyntaxError` is not in coffee-script 1.6.x, so we need to make sure to specify the coffee-script version to 1.7.x. Depending on coffee-script version `*` can cause a problem if: top level project uses the latest version of node-connect-coffee-script, but also depends on coffee-script 1.6.x. Because of npm's dependency resolution, if it sees `"coffee-script" : "*"` in node-connect-coffee-script's `package.json`, it will think this is already satisfied with coffee-script 1.6.x and won't install the latest version. So if there is ever a syntax error, it won't show up properly because `updateSyntaxError` doesn't exist.

Also, in general I think it is a good idea to depend on a specific minor version of coffee-script because there might be breaking changes across versions that require updating this package.
